### PR TITLE
Converted all 'px' units with 'rem' unit in demo.css files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 
 
-College-Notes-Gallery ->
+College-Notes-Gallery-- ->
 
 ![home](https://user-images.githubusercontent.com/16975766/28489136-9c9930a0-6ed8-11e7-85a0-af4d73f63cd7.png)
 

--- a/css/demo.css
+++ b/css/demo.css
@@ -1,10 +1,15 @@
 /* CSS reset */
-body,div,dl,dt,dd,ul,ol,li,h1,h2,h3,h4,h5,h6,pre,form,fieldset,input,textarea,p,blockquote,th,td { 
+* { 
 	margin:0;
 	padding:0;
+	box-sizing: border-box;
+}
+/* sets 1rem = 10px */
+html {
+	font-size: 62.5%; 
 }
 html,body {
-	margin:50px;
+	margin:5rem;
 	padding:0;
 	height: 100%;
 }
@@ -37,7 +42,7 @@ body{
 	font-family: Cambria, Palatino, "Palatino Linotype", "Palatino LT STD", Georgia, serif;
 	background:url(images/bgnoise_lg.png);
 	font-weight: 400;
-	font-size: 15px;
+	font-size: 1.5rem;
 	color: #3a2127;
 	overflow-y: scroll;
 }
@@ -46,7 +51,7 @@ a{
 	text-decoration: none;
 }
 .container{
-        margin: margin: 0px 20px 10px 20px;
+        margin: margin: 0px 2rem 1rem 2rem;
 	width: 100%;
 	height: 100%;
 	position: relative;
@@ -55,8 +60,8 @@ a{
 	clear: both;
 }
 .container > header{
-	padding: 20px 30px 20px 30px;
-	margin: 0px 20px 10px 20px;
+	padding: 2rem 3rem 2rem 3rem;
+	margin: 0px 2rem 1rem 2rem;
 	position: relative;
 	display: block;
 	text-shadow: 1px 1px 1px rgba(0,0,0,0.2);
@@ -67,14 +72,14 @@ a{
 	color: #498ea5;
 	font-weight: 700;
 	font-style: normal;
-	font-size: 30px;
-	padding: 0px 0px 5px 0px;
+	font-size: 3rem;
+	padding: 0px 0px 0.5rem 0px;
 	text-shadow: 0px 1px 1px rgba(255,255,255,0.8);
 }
 .container > header h1 span{
 	font-family: 'Alegreya SC', Georgia, serif;
-	font-size: 20px;
-	line-height: 20px;
+	font-size: 2rem;
+	line-height: 2rem;
 	display: block;
 	font-weight: 400;
 	font-style: italic;
@@ -82,15 +87,15 @@ a{
 	text-shadow: 1px 1px 1px rgba(0,0,0,0.1);
 }
 .container > header h2{
-	font-size: 16px;
+	font-size: 1.6rem;
 	font-style: italic;
 	color: #2d6277;
 	text-shadow: 0px 1px 1px rgba(255,255,255,0.8);
 }
 /* Header Style */
 .freshdesignweb-top{
-	line-height: 24px;
-	font-size: 11px;
+	line-height: 2.4rem;
+	font-size: 1.1rem;
 	background: rgba(0, 0, 0, 0.05);
 	text-transform: uppercase;
 	z-index: 9999;
@@ -98,7 +103,7 @@ a{
 	box-shadow: 1px 0px 2px rgba(0,0,0,0.2);
 }
 .freshdesignweb-top a{
-	padding: 0px 10px;
+	padding: 0px 1rem;
 	letter-spacing: 1px;
 	color: #333;
 	text-shadow: 0px 1px 1px #fff;
@@ -118,18 +123,18 @@ a{
 .freshdesignweb-demos{
     text-align:center;
 	display: block;
-	line-height: 30px;
-	padding: 20px 0px;
+	line-height: 3rem;
+	padding: 2rem 0px;
 }
 .freshdesignweb-demos a{
     display: inline-block;
-	margin: 0px 4px;
-	padding: 0px 4px;
+	margin: 0px 0.4rem;
+	padding: 0px 0.4rem;
 	color: #fff;
-	line-height: 20px;	
+	line-height: 2rem;	
 	font-style: italic;
-	font-size: 13px;
-	border-radius: 3px;
+	font-size: 1.3rem;
+	border-radius: 0.3rem;
 	background: rgba(41,77,95,0.1);
 	-webkit-transition: all 0.2s linear;
 	-moz-transition: all 0.2s linear;

--- a/dashboard/css/cms-home.css
+++ b/dashboard/css/cms-home.css
@@ -5,9 +5,9 @@
  */
 
 body {
-    padding-top: 70px; /* Required padding for .navbar-fixed-top. Remove if using .navbar-static-top. Change if height of navigation changes. */
+    padding-top: 4.375rem; /* Required padding for .navbar-fixed-top. Remove if using .navbar-static-top. Change if height of navigation changes. */
 }
 
 footer {
-    margin: 50px 0;
+    margin: 3.125rem 0;
 }

--- a/demo.css
+++ b/demo.css
@@ -1,7 +1,12 @@
 /* CSS reset */
-body,div,dl,dt,dd,ul,ol,li,h1,h2,h3,h4,h5,h6,pre,form,fieldset,input,textarea,p,blockquote,th,td { 
+* { 
 	margin:0;
 	padding:0;
+	box-sizing: border-box;
+}
+/* sets 1rem = 10px; */
+html {
+	font-size: 62.5%;
 }
 html,body {
 	margin:0;
@@ -42,7 +47,7 @@ body{
 	font-family: Cambria, Palatino, "Palatino Linotype", "Palatino LT STD", Georgia, serif;
 	background:url(images/bgnoise_lg.png);
 	font-weight: 400;
-	font-size: 15px;
+	font-size: 1.5rem;
 	color: #3a2127;
 	overflow-y: scroll;
 }
@@ -59,8 +64,8 @@ a{
 	clear: both;
 }
 .container > header{
-	padding: 20px 30px 20px 30px;
-	margin: 0px 20px 10px 20px;
+	padding: 2rem 3rem 2rem 3rem;
+	margin: 0rem 2rem 1rem 2rem;
 	position: relative;
 	display: block;
 	text-shadow: 1px 1px 1px rgba(0,0,0,0.2);
@@ -71,14 +76,14 @@ a{
 	color: #498ea5;
 	font-weight: 700;
 	font-style: normal;
-	font-size: 30px;
-	padding: 0px 0px 5px 0px;
+	font-size: 3rem;
+	padding: 0px 0px .5rem 0px;
 	text-shadow: 0px 1px 1px rgba(255,255,255,0.8);
 }
 .container > header h1 span{
 	font-family: 'Alegreya SC', Georgia, serif;
-	font-size: 20px;
-	line-height: 20px;
+	font-size: 2rem;
+	line-height: 2rem;
 	display: block;
 	font-weight: 400;
 	font-style: italic;
@@ -86,15 +91,15 @@ a{
 	text-shadow: 1px 1px 1px rgba(0,0,0,0.1);
 }
 .container > header h2{
-	font-size: 16px;
+	font-size: 1.6rem;
 	font-style: italic;
 	color: #2d6277;
 	text-shadow: 0px 1px 1px rgba(255,255,255,0.8);
 }
 /* Header Style */
 .freshdesignweb-top{
-	line-height: 24px;
-	font-size: 11px;
+	line-height: 2.4rem;
+	font-size: 1.1rem;
 	background: rgba(0, 0, 0, 0.05);
 	text-transform: uppercase;
 	z-index: 9999;
@@ -102,7 +107,7 @@ a{
 	box-shadow: 1px 0px 2px rgba(0,0,0,0.2);
 }
 .freshdesignweb-top a{
-	padding: 0px 10px;
+	padding: 0px 1rem;
 	letter-spacing: 1px;
 	color: #333;
 	text-shadow: 0px 1px 1px #fff;
@@ -122,18 +127,18 @@ a{
 .freshdesignweb-demos{
     text-align:center;
 	display: block;
-	line-height: 30px;
-	padding: 20px 0px;
+	line-height: 3rem;
+	padding: 2rem 0rem;
 }
 .freshdesignweb-demos a{
     display: inline-block;
-	margin: 0px 4px;
+	margin: 0px .4rem;
 	padding: 0px 4px;
 	color: #fff;
-	line-height: 20px;	
+	line-height: 2rem;	
 	font-style: italic;
-	font-size: 13px;
-	border-radius: 3px;
+	font-size: 1.3rem;
+	border-radius: .3rem;
 	background: rgba(41,77,95,0.1);
 	-webkit-transition: all 0.2s linear;
 	-moz-transition: all 0.2s linear;

--- a/includes/header.php
+++ b/includes/header.php
@@ -6,6 +6,7 @@ include('connection.php');
 <html>
 <head>
 <title>College-Notes-Gallery</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
  <script src="dashboard/js/tinymce/tinymce.min.js"></script>
     <script src="dashboard/js/tinymce/script.js"></script>
 	<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css">


### PR DESCRIPTION
I've converted 'px' units with 'rem' units, where "1rem = 10px", by setting: html { font-size: 62.5%; }. This will give a better experience when using media queries. So, we just have to change the font-size of html in each media query, instead of changing each property value with aclculated 'px'. I just changed in demo.css and you may like it.